### PR TITLE
Link frontend to backend API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 ml/data/
 ml/results/
 *venv*/
+*.DS_Store

--- a/backend/osssimbackend/simRestApi/views.py
+++ b/backend/osssimbackend/simRestApi/views.py
@@ -1446,29 +1446,6 @@ class ProjectPredictionHistoryView(APIView):
             if not prediction_history:
                 return Response({"error": "Project does not have prediction history"}, status=status.HTTP_404_NOT_FOUND)
 
-            # Calculate p_graduate from confidence
-            for month_entry in prediction_history:
-                for month_key, data in month_entry.items():
-                    if "p_graduate" not in data or data["p_graduate"] is None:
-
-                        prediction = data.get("prediction", None)
-                        confidence = data.get("confidence", None)
-
-                        if prediction is not None and confidence is not None:
-                            p_graduate = confidence if prediction == 1 else 1 - confidence
-                        else:
-                            p_graduate = None
-
-                        data["p_graduate"] = p_graduate
-            
-
-
-            # Ensure updated data is used in the response
-            serialized_history = []
-            for entry in prediction_history:
-                serializer = MonthPredictionSerializer(instance=entry)
-                serialized_history.append(serializer.data)
-
             response_data = {
                 "project_id": project_id,
                 "project_name": project_info["listname"],
@@ -1478,7 +1455,7 @@ class ProjectPredictionHistoryView(APIView):
                 "pj_github_url": project_info["pj_github_url"],
                 "intro": project_info["intro"],
                 "sponsor": project_info["sponsor"],
-                "prediction_history": serialized_history
+                "prediction_history": prediction_history
             }
 
             # Cache the result for 1 hour
@@ -1921,15 +1898,5 @@ class SimulateWithDeltasView(APIView):
             "project_id": project_id,
             "predictions": predictions
         }
-        # predicted_class, confidence, p_graduate = predict(modified_history, model_path, max_months)
-        # status = "Sustainable (Likely to Graduate)" if predicted_class == 1 else "Not Sustainable (Likely to Retire)"
-
-        # # Prepare Response
-        # response_data = {
-        #     "project_id": project_id,
-        #     "predicted_status": status,
-        #     "confidence_score": round(confidence, 2),
-        #     "modified_features": feature_changes,
-        #     "p_graduate": round(p_graduate, 2)
 
         return Response(response_data, status=200)

--- a/frontend/src/components/FeatureGraph/FeatureGraph.jsx
+++ b/frontend/src/components/FeatureGraph/FeatureGraph.jsx
@@ -112,7 +112,7 @@ export default function FeatureGraph() {
         .range([margin.left, size.width - margin.right]);
       const yScale = d3
         .scaleLinear()
-        .domain([0, Math.max(dataRange[1], changedDataRange[1]) * 1.25])
+        .domain([0, Math.max(dataRange[1], changedDataRange[1])])
         .range([size.height - margin.bottom, margin.top]);
       const xAxis = d3.axisBottom(xScale).ticks(data.length);
       const yAxis = d3
@@ -140,7 +140,11 @@ export default function FeatureGraph() {
       svg
         .select('#title')
         .attr('transform', `translate(${size.width / 2}, ${margin.top / 2})`)
-        .text(`${selectedFeature} over time`)
+        .text(
+          simContext.selectedProject?.project_id
+            ? `${selectedFeature} over time`
+            : 'Select a project to view feature data.',
+        )
         .attr('text-anchor', 'middle')
         .style('font-size', '1.1rem')
         .style('font-family', "'Roboto', sans-serif");

--- a/frontend/src/components/FeatureGraph/FeatureGraph.jsx
+++ b/frontend/src/components/FeatureGraph/FeatureGraph.jsx
@@ -66,6 +66,7 @@ export default function FeatureGraph() {
   const simContext = useSimulation();
   const { month: selectedMonth, feature: selectedFeature } =
     simContext.selectedFeature;
+  // Stretch goal: change to scrollable graph
   const inFocusRange = (month, centerMonth) => {
     const monthMargin = 3; // display a quarter of data on each side
     // TODO: add extra months on left or right if total shown < margin * 2 + 1
@@ -79,12 +80,11 @@ export default function FeatureGraph() {
     );
   };
 
-  const data = simContext.selectedProjectData.features
-    .map((d) => ({
-      month: d.month,
-      value: d[selectedFeature],
-    }))
-    .filter((d) => inFocusRange(d.month, selectedMonth));
+  const data = simContext.selectedProjectData.features.map((d) => ({
+    month: d.month,
+    value: d[selectedFeature],
+  }));
+  //.filter((d) => inFocusRange(d.month, selectedMonth));
 
   useEffect(() => {
     const renderGraph = (data) => {
@@ -97,7 +97,8 @@ export default function FeatureGraph() {
         } else return original;
       });
       const dataDomain = d3.extent(changedData.map((d) => d.month));
-      const dataRange = d3.extent(changedData.map((d) => d.value));
+      const changedDataRange = d3.extent(changedData.map((d) => d.value));
+      const dataRange = d3.extent(data.map((d) => d.value));
 
       const margin = {
         top: size.height * 0.2,
@@ -111,7 +112,7 @@ export default function FeatureGraph() {
         .range([margin.left, size.width - margin.right]);
       const yScale = d3
         .scaleLinear()
-        .domain([0, dataRange[1] * 1.25])
+        .domain([0, Math.max(dataRange[1], changedDataRange[1]) * 1.25])
         .range([size.height - margin.bottom, margin.top]);
       const xAxis = d3.axisBottom(xScale).ticks(data.length);
       const yAxis = d3
@@ -193,7 +194,7 @@ export default function FeatureGraph() {
         .selectAll('circle')
         .data(data)
         .join('circle')
-        .attr('r', '7px')
+        .attr('r', '5px')
         .attr('cx', (d) => xScale(d.month))
         .attr('cy', (d) => yScale(d.value))
         .attr('fill', 'green')
@@ -220,7 +221,7 @@ export default function FeatureGraph() {
         .selectAll('circle')
         .data(changedData)
         .join('circle')
-        .attr('r', '7px')
+        .attr('r', '5px')
         .attr('cx', (d) => xScale(d.month))
         .attr('cy', (d) => yScale(d.value))
         .attr('fill', 'rgb(224, 186, 34)')

--- a/frontend/src/components/ForecastGraph/ForecastGraph.jsx
+++ b/frontend/src/components/ForecastGraph/ForecastGraph.jsx
@@ -90,8 +90,8 @@ export default function ForecastGraph() {
         .attr('y', margin.top * 0.75)
         .text(
           simContext.selectedProject?.project_id
-            ? `Sustainability forecasts for ${simContext.selectedProjectData.details.project_name}`
-            : 'Select project from dropdown to get started.',
+            ? `Sustainability predictions for ${simContext.selectedProjectData.details.project_name}`
+            : 'Select project to view prediction data.',
         )
         .attr('text-anchor', 'middle')
         .style('font-size', '1.25rem')

--- a/frontend/src/components/Header/Header.jsx
+++ b/frontend/src/components/Header/Header.jsx
@@ -22,6 +22,7 @@ import {
 } from '../endpoints';
 
 // TODO: set default
+// TODO: add confirm dialogue when changing project with non-empty simulated changes
 function ProjectSelect() {
   const simContext = useSimulation();
   const simDispatch = useSimulationDispatch();
@@ -92,6 +93,7 @@ function ProjectSelect() {
       simDispatch({
         type: 'set_selected_project',
         selectedValue: selected,
+        id: selected.project_id,
         projectDetails: detailsJson,
         historicalFeatureData: featuresJson,
       });

--- a/frontend/src/components/Header/Header.jsx
+++ b/frontend/src/components/Header/Header.jsx
@@ -98,6 +98,13 @@ function ProjectSelect() {
     } catch (e) {
       // TODO: add Snackbar for fetch feedback
       console.log(e);
+      simDispatch({
+        type: 'set_selected_project',
+        selectedValue: selected,
+        id: selected.project_id,
+        projectDetails: {},
+        historicalFeatureData: {},
+      });
     }
   };
 

--- a/frontend/src/components/Header/Header.jsx
+++ b/frontend/src/components/Header/Header.jsx
@@ -10,58 +10,38 @@ import TextField from '@mui/material/TextField';
 import Toolbar from '@mui/material/Toolbar';
 import match from 'autosuggest-highlight/match';
 import parse from 'autosuggest-highlight/parse';
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import {
   useSimulation,
   useSimulationDispatch,
 } from '../context/SimulationContext';
+import {
+  GET_PROJECT_DETAILS,
+  GET_PROJECT_HISTORICAL_DATA,
+  LIST_PROJECTS,
+} from '../endpoints';
 
 // TODO: set default
 function ProjectSelect() {
   const simContext = useSimulation();
   const simDispatch = useSimulationDispatch();
+  const [options, setOptions] = useState([]);
 
-  // TODO: fetch from backend
-  const projectOptions = useMemo(
-    () => [
-      {
-        project_id: '1',
-        project_name: 'Amaterasu',
-        status: 'Retired',
-      },
-      {
-        project_id: '2',
-        project_name: 'Annotator',
-        status: 'Retired',
-      },
-      {
-        project_id: '3',
-        project_name: 'BatchEE',
-        status: 'Retired',
-      },
-      {
-        project_id: '4',
-        project_name: 'BRPC',
-        status: 'Retired',
-      },
-      {
-        project_id: '242',
-        project_name: 'Usergrid',
-        status: 'Graduated',
-      },
-      {
-        project_id: '243',
-        project_name: 'VCL',
-        status: 'Graduated',
-      },
-      {
-        project_id: '244',
-        project_name: 'VXQuery',
-        status: 'Graduated',
-      },
-    ],
-    [],
-  );
+  const projectOptions = useMemo(() => {
+    fetch(LIST_PROJECTS)
+      .then((res) => res.json())
+      .then((json) => {
+        const sortedOptions = json.projects.sort(
+          (a, b) =>
+            -b.status.localeCompare(a.status) ||
+            -b.project_name[0]
+              .toUpperCase()
+              .localeCompare(a.project_name[0].toUpperCase()),
+        );
+        setOptions(json.projects);
+      });
+    return [];
+  }, []);
 
   const renderOptionWithAutocomplete = (props, option, { inputValue }) => {
     // eslint-disable-next-line react/prop-types
@@ -87,6 +67,40 @@ function ProjectSelect() {
     );
   };
 
+  const handleSelectProject = async (selected) => {
+    try {
+      // Get project details + prediction history
+      const detailsParams = new URLSearchParams();
+      detailsParams.append('project_id', selected.project_id);
+      const detailsRes = await fetch(`${GET_PROJECT_DETAILS}?${detailsParams}`);
+      const detailsJson = await detailsRes.json();
+      // console.log(detailsJson);
+
+      // Get historical feature data
+      const histDataParams = new URLSearchParams();
+      // histDataParams.append('num_months', projectDetails.history.length);
+      histDataParams.append(
+        'num_months',
+        detailsJson.prediction_history.length,
+      );
+      histDataParams.append('project_id', selected.project_id);
+      const featuresRes = await fetch(
+        `${GET_PROJECT_HISTORICAL_DATA}?${histDataParams}`,
+      );
+      const featuresJson = await featuresRes.json();
+      // console.log(featuresJson);
+      simDispatch({
+        type: 'set_selected_project',
+        selectedValue: selected,
+        projectDetails: detailsJson,
+        historicalFeatureData: featuresJson,
+      });
+    } catch (e) {
+      // TODO: add Snackbar for fetch feedback
+      console.log(e);
+    }
+  };
+
   return (
     <div className="project-select">
       <Autocomplete
@@ -97,6 +111,7 @@ function ProjectSelect() {
         selectOnFocus
         getOptionLabel={(option) => option?.project_name ?? ''}
         groupBy={(option) => option.status}
+        options={options}
         renderOption={renderOptionWithAutocomplete}
         size="small"
         sx={{ width: 300, '& fieldset': { borderRadius: 3 } }}
@@ -104,22 +119,10 @@ function ProjectSelect() {
         isOptionEqualToValue={(option, value) =>
           option.project_id === value?.project_id
         }
-        options={projectOptions.sort(
-          (a, b) =>
-            -b.project_name[0]
-              .toUpperCase()
-              .localeCompare(a.project_name[0].toUpperCase()),
-        )}
         renderInput={(params) => (
           <TextField {...params} label="Select project" />
         )}
-        onChange={(_, selected) => {
-          console.log(selected);
-          simDispatch({
-            type: 'set_selected_project',
-            selectedValue: selected,
-          });
-        }}
+        onChange={(_, selected) => handleSelectProject(selected)}
       />
     </div>
   );

--- a/frontend/src/components/Header/Header.jsx
+++ b/frontend/src/components/Header/Header.jsx
@@ -21,7 +21,6 @@ import {
   LIST_PROJECTS,
 } from '../endpoints';
 
-// TODO: set default
 // TODO: add confirm dialogue when changing project with non-empty simulated changes
 function ProjectSelect() {
   const simContext = useSimulation();

--- a/frontend/src/components/ProjectDetails/ProjectDetails.jsx
+++ b/frontend/src/components/ProjectDetails/ProjectDetails.jsx
@@ -27,22 +27,35 @@ export default function ProjectDetails() {
     month: 'short',
     day: 'numeric',
   };
-  const activeDates = `${startDate.toLocaleDateString(undefined, dateFormat)} - ${endDate.toLocaleDateString(undefined, dateFormat)}`;
+  const activeDates = simContext.selectedProjectData.id
+    ? `${startDate.toLocaleDateString(undefined, dateFormat)} - ${endDate.toLocaleDateString(undefined, dateFormat)}`
+    : '';
 
   return (
     <>
       <Stack direction="row" gap={1} sx={{ alignItems: 'center' }}>
-        <Typography variant="h6">{projectDetails.project_name}</Typography>
-        <StyledTooltip arrow title={projectDetails.intro}>
-          <InfoIcon
-            fontSize="small"
-            sx={{ alignmentBaseline: 'after-edge', color: 'grey' }}
-          />
-        </StyledTooltip>
+        <Typography variant="h6">
+          {simContext.selectedProjectData.id === null
+            ? 'Select a project to see details.'
+            : projectDetails.project_name}
+        </Typography>
+        {simContext.selectedProjectData.id && (
+          <StyledTooltip arrow title={projectDetails.intro}>
+            <InfoIcon
+              fontSize="small"
+              sx={{ alignmentBaseline: 'after-edge', color: 'grey' }}
+            />
+          </StyledTooltip>
+        )}
       </Stack>
       <Typography variant="body1">Active: {activeDates}</Typography>
       <Typography variant="body1">
-        Status: {projectDetails.status ? 'Graduated' : 'Retired'}
+        Status:{' '}
+        {simContext.selectedProjectData.id
+          ? projectDetails.status
+            ? 'Graduated'
+            : 'Retired'
+          : ''}
       </Typography>
       <Typography variant="body1">Sponsor: {projectDetails.sponsor}</Typography>
       <Typography variant="body1">

--- a/frontend/src/components/ProjectDetails/ProjectDetails.jsx
+++ b/frontend/src/components/ProjectDetails/ProjectDetails.jsx
@@ -1,18 +1,46 @@
+import InfoIcon from '@mui/icons-material/Info';
 import { Typography } from '@mui/material';
 import Link from '@mui/material/Link';
+import Stack from '@mui/material/Stack';
+import { styled } from '@mui/material/styles';
+import Tooltip, { tooltipClasses } from '@mui/material/Tooltip';
 import React from 'react';
 import { useSimulation } from '../context/SimulationContext';
+
+const StyledTooltip = styled(({ className, ...props }) => (
+  <Tooltip {...props} classes={{ popper: className }} />
+))(({ theme }) => ({
+  [`& .${tooltipClasses.tooltip}`]: {
+    boxShadow: theme.shadows[1],
+    fontSize: 14,
+  },
+}));
 
 export default function ProjectDetails() {
   const simContext = useSimulation();
   const projectDetails = simContext.selectedProjectData.details;
 
+  const startDate = new Date(projectDetails.start_date);
+  const endDate = new Date(projectDetails.end_date);
+  const dateFormat = {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  };
+  const activeDates = `${startDate.toLocaleDateString(undefined, dateFormat)} - ${endDate.toLocaleDateString(undefined, dateFormat)}`;
+
   return (
     <>
-      <Typography variant="h6">{projectDetails.project_name}</Typography>
-      <Typography variant="body1">
-        Active: {projectDetails.start_date + ' - ' + projectDetails.end_date}
-      </Typography>
+      <Stack direction="row" gap={1} sx={{ alignItems: 'center' }}>
+        <Typography variant="h6">{projectDetails.project_name}</Typography>
+        <StyledTooltip arrow title={projectDetails.intro}>
+          <InfoIcon
+            fontSize="small"
+            sx={{ alignmentBaseline: 'after-edge', color: 'grey' }}
+          />
+        </StyledTooltip>
+      </Stack>
+      <Typography variant="body1">Active: {activeDates}</Typography>
       <Typography variant="body1">
         Status: {projectDetails.status ? 'Graduated' : 'Retired'}
       </Typography>
@@ -26,9 +54,6 @@ export default function ProjectDetails() {
         >
           {projectDetails.pj_github_url}
         </Link>
-      </Typography>
-      <Typography sx={{ fontStyle: 'italic' }} variant="body">
-        {projectDetails.intro}
       </Typography>
     </>
   );

--- a/frontend/src/components/UpdateFeatures/DeltaSelector.jsx
+++ b/frontend/src/components/UpdateFeatures/DeltaSelector.jsx
@@ -45,8 +45,7 @@ function DeltaSelector() {
   };
 
   // Generate valid month options
-  // TODO: memoize these
-  const nMonths = 12; // TODO: get # available months from project feature/pred history in context
+  const nMonths = simContext.selectedProjectData.features.length;
   const startMonths = Array.from(Array(nMonths), (_, x) => x + 1).filter(
     (m) => !selectedMonths.has(m),
   );

--- a/frontend/src/components/UpdateFeatures/FeatureEditor.jsx
+++ b/frontend/src/components/UpdateFeatures/FeatureEditor.jsx
@@ -4,7 +4,8 @@ import ReplayIcon from '@mui/icons-material/Replay';
 import SouthWestIcon from '@mui/icons-material/SouthWest';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
-import Tooltip from '@mui/material/Tooltip';
+import { styled } from '@mui/material/styles';
+import Tooltip, { tooltipClasses } from '@mui/material/Tooltip';
 import { DataGrid, GridActionsCellItem, useGridApiRef } from '@mui/x-data-grid';
 import PropTypes from 'prop-types';
 import React, { useEffect } from 'react';
@@ -20,6 +21,16 @@ import {
 } from '../utils.js';
 import { FEATURE_DESCRIPTIONS } from './constants';
 
+const StyledTooltip = styled(({ className, ...props }) => (
+  <Tooltip {...props} classes={{ popper: className }} />
+))(({ theme }) => ({
+  [`& .${tooltipClasses.tooltip}`]: {
+    boxShadow: theme.shadows[1],
+    fontSize: 13,
+  },
+}));
+
+// TODO: disable % change if original value is 0. handle case for copy to range as well.
 // TODO: documentation
 // TODO: known issue - if you edit then exit editing too quick (e.g. typing new value then pressing enter right after),
 //       it will fail to save, and you have to re-click and re-exit to save it properly.
@@ -42,7 +53,12 @@ export default function FeatureEditor() {
       includeOutliers: true,
       includeHeaders: true,
     });
-  }, [dataGridApiRef, simContext.selectedPeriod]);
+  }, [
+    dataGridApiRef,
+    selectedData,
+    simContext.simulationData.changes,
+    simContext.selectedProject,
+  ]);
 
   const rows = pivot(selectedData, simContext.simulationData.changes);
   const columns = [
@@ -59,12 +75,12 @@ export default function FeatureEditor() {
             sx={{ width: 'fit-content', mr: 0.5 }}
           >
             {value}
-            <Tooltip title={FEATURE_DESCRIPTIONS.get(value)}>
+            <StyledTooltip arrow title={FEATURE_DESCRIPTIONS.get(value)}>
               <HelpIcon
                 fontSize="inherit"
                 sx={{ alignmentBaseline: 'after-edge', color: 'grey' }}
               />
-            </Tooltip>
+            </StyledTooltip>
           </Stack>
         );
       },
@@ -151,7 +167,7 @@ export default function FeatureEditor() {
       cellClassName: 'actions',
       getActions: (params) => {
         return [
-          <Tooltip key={params.id + '_reset'} title="Reset">
+          <StyledTooltip key={params.id + '_reset'} title="Reset">
             <GridActionsCellItem
               className="textPrimary"
               color="inherit"
@@ -161,8 +177,8 @@ export default function FeatureEditor() {
                 simDispatch({ type: 'delete_change', gridRowParams: params })
               }
             />
-          </Tooltip>,
-          <Tooltip
+          </StyledTooltip>,
+          <StyledTooltip
             key={params.id + '_copyToAll'}
             title="Copy % change to all months for feature"
           >
@@ -177,8 +193,11 @@ export default function FeatureEditor() {
                 })
               }
             />
-          </Tooltip>,
-          <Tooltip key={params.id + '_inspectFeature'} title="Inspect feature">
+          </StyledTooltip>,
+          <StyledTooltip
+            key={params.id + '_inspectFeature'}
+            title="Inspect feature"
+          >
             <GridActionsCellItem
               color="inherit"
               icon={<QueryStatsIcon />}
@@ -190,7 +209,7 @@ export default function FeatureEditor() {
                 })
               }
             />
-          </Tooltip>,
+          </StyledTooltip>,
         ];
       },
     },

--- a/frontend/src/components/UpdateFeatures/UpdateFeatures.jsx
+++ b/frontend/src/components/UpdateFeatures/UpdateFeatures.jsx
@@ -1,17 +1,107 @@
-import UploadIcon from '@mui/icons-material/Upload';
+import TimelineIcon from '@mui/icons-material/Timeline';
 import { Typography } from '@mui/material';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
+import { styled } from '@mui/material/styles';
+import Tooltip, { tooltipClasses } from '@mui/material/Tooltip';
 import { isEmpty } from 'lodash';
 import React, { useState } from 'react';
-import { useSimulation } from '../context/SimulationContext';
+import {
+  useSimulation,
+  useSimulationDispatch,
+} from '../context/SimulationContext';
+import { SIMULATE_WITH_DELTAS } from '../endpoints';
 import DeltaList from './DeltaList';
 import DeltaSelector from './DeltaSelector';
 import FeatureEditor from './FeatureEditor';
 
+const StyledTooltip = styled(({ className, ...props }) => (
+  <Tooltip {...props} classes={{ popper: className }} />
+))(({ theme }) => ({
+  [`& .${tooltipClasses.tooltip}`]: {
+    boxShadow: theme.shadows[1],
+    fontSize: 13,
+  },
+}));
+
+const SAMPLE_DELTAS = {
+  project_id: '200',
+  deltas: [
+    {
+      months: [1, 3],
+      feature_changes: [
+        {
+          feature_name: 'num_commits',
+          change_type: 'percentage',
+          change_value: 20,
+        },
+        {
+          feature_name: 'num_files',
+          change_type: 'explicit',
+          change_values: [100, 150],
+        },
+      ],
+    },
+    {
+      months: [6, 7],
+      feature_changes: [
+        {
+          feature_name: 'num_commits',
+          change_type: 'explicit',
+          change_value: 2,
+        },
+        {
+          feature_name: 'num_files',
+          change_type: 'explicit',
+          change_values: [13, 5],
+        },
+      ],
+    },
+  ],
+};
+
 function UpdateFeatures() {
   const simContext = useSimulation();
+  const simDispatch = useSimulationDispatch();
   const [submitting, setSubmitting] = useState(false);
+
+  const handleSimulateChanges = async () => {
+    const deltas = [...simContext.simulationData.changes.values()].map((v) => ({
+      months: [v.month],
+      feature_changes: [
+        {
+          feature_name: v.feature,
+          change_type: 'explicit',
+          change_value: v.new_value,
+        },
+      ],
+    }));
+    try {
+      setSubmitting(true);
+      const simResponse = await fetch(SIMULATE_WITH_DELTAS, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          project_id: simContext.selectedProject.project_id,
+          deltas: deltas,
+        }),
+      });
+
+      const simResults = await simResponse.json();
+      simDispatch({
+        type: 'set_simulation_results',
+        data: simResults.predictions,
+      });
+      setSubmitting(false);
+    } catch (e) {
+      console.log(`Error simulating changes=${deltas}.`);
+      console.log(e);
+      setSubmitting(false);
+    }
+  };
+
   return (
     <Box
       sx={{
@@ -47,24 +137,47 @@ function UpdateFeatures() {
           <DeltaList />
         </Box>
         <Box sx={{ gridColumn: 3 }}>
-          <Button
-            disableElevation
-            disabled={isEmpty(simContext.simulationData?.changes)}
-            endIcon={<UploadIcon />}
-            loading={submitting}
-            loadingPosition="end"
-            size="large"
-            variant="contained"
-            sx={{
-              fontFamily: 'inherit',
-              fontWeight: 400,
-              px: 2,
-              borderRadius: 3,
+          <StyledTooltip
+            arrow
+            slotProps={{
+              popper: {
+                modifiers: [
+                  {
+                    name: 'offset',
+                    options: {
+                      offset: [0, 8],
+                    },
+                  },
+                ],
+              },
             }}
-            onClick={() => setSubmitting(true)}
+            title={
+              isEmpty(simContext.simulationData?.changes)
+                ? 'No changes to simulate.'
+                : ''
+            }
           >
-            Simulate
-          </Button>
+            <span>
+              <Button
+                disableElevation
+                disabled={isEmpty(simContext.simulationData?.changes)}
+                endIcon={<TimelineIcon />}
+                loading={submitting}
+                loadingPosition="end"
+                size="large"
+                variant="contained"
+                sx={{
+                  fontFamily: 'inherit',
+                  fontWeight: 400,
+                  px: 2,
+                  borderRadius: 3,
+                }}
+                onClick={() => handleSimulateChanges()}
+              >
+                Simulate
+              </Button>
+            </span>
+          </StyledTooltip>
         </Box>
       </Box>
       <Box

--- a/frontend/src/components/context/SimulationContextProvider.jsx
+++ b/frontend/src/components/context/SimulationContextProvider.jsx
@@ -52,10 +52,10 @@ function simulationReducer(prev, action) {
         ...prev,
         selectedProject: action.selectedValue,
         selectedProjectData: {
-          id: action.projectDetails.project_id,
+          id: action.id,
           details: projectDetails,
-          predictions: action.projectDetails.prediction_history,
-          features: action.historicalFeatureData.history,
+          predictions: action.projectDetails.prediction_history || [],
+          features: action.historicalFeatureData.history || [],
         },
       };
     }
@@ -255,6 +255,14 @@ const DUMMY_SIM = {
     changes: new Map(DUMMY_CHANGES.map((c) => [c.id, c.change])),
     selectedPeriod: { key: '1_1', startMonth: 1, endMonth: 1 },
   },
+  simulatedPredictions: [
+    { month: 10, p_grad: 0.1 },
+    { month: 13, p_grad: 0.5 },
+    { month: 14, p_grad: 0.3 },
+    { month: 15, p_grad: 0.1 },
+    { month: 16, p_grad: 0.7 },
+    { month: 17, p_grad: 0.7 },
+  ],
 };
 
 SimulationContextProvider.propTypes = {

--- a/frontend/src/components/context/SimulationContextProvider.jsx
+++ b/frontend/src/components/context/SimulationContextProvider.jsx
@@ -1,3 +1,4 @@
+import { pick } from 'lodash';
 import React, { useEffect, useReducer } from 'react';
 import { DUMMY_CHANGES, DUMMY_DATA } from '../UpdateFeatures/constants';
 import {
@@ -18,6 +19,13 @@ export function SimulationContextProvider({ children }) {
     console.log('Saved changes updated: ', simulation.simulationData.changes);
   }, [simulation.simulationData.changes]);
 
+  useEffect(() => {
+    console.log(
+      'Saved project details updated: ',
+      simulation.selectedProjectData,
+    );
+  }, [simulation.selectedProjectData]);
+
   return (
     <SimulationContext.Provider value={simulation}>
       <SimulationDispatchContext.Provider value={dispatch}>
@@ -30,10 +38,25 @@ export function SimulationContextProvider({ children }) {
 function simulationReducer(prev, action) {
   switch (action.type) {
     case 'set_selected_project': {
-      // TODO: load data from server into selectedProjectData
+      const projectDetails = pick(action.projectDetails, [
+        'project_name',
+        'start_date',
+        'end_date',
+        'status',
+        'pj_github_url',
+        'intro',
+        'sponsor',
+      ]);
+
       return {
         ...prev,
         selectedProject: action.selectedValue,
+        selectedProjectData: {
+          id: action.projectDetails.project_id,
+          details: projectDetails,
+          predictions: action.projectDetails.prediction_history,
+          features: action.historicalFeatureData.history,
+        },
       };
     }
     case 'set_selected_period': {
@@ -41,7 +64,9 @@ function simulationReducer(prev, action) {
         ...prev,
         selectedFeature: {
           ...prev.selectedFeature,
-          month: action.period.startMonth,
+          month: Math.round(
+            action.period.startMonth + action.period.endMonth / 2,
+          ),
         },
         simulationData: {
           ...prev.simulationData,
@@ -186,17 +211,21 @@ function simulationReducer(prev, action) {
         },
       };
     }
+    case 'simulate_changes': {
+      return prev;
+    }
     default: {
       throw Error('Unknown simulationReducer action: ' + action.type);
     }
   }
 }
 
+// TODO: set all data to null and check for NPEs
 const DUMMY_SIM = {
   selectedProject: {
-    project_id: '1',
-    project_name: 'Amaterasu',
-    status: 'Retired',
+    // project_id: '49',
+    // project_name: 'Abdera',
+    // status: 'Graduated',
   },
   selectedProjectData: {
     id: '112',

--- a/frontend/src/components/context/SimulationContextProvider.jsx
+++ b/frontend/src/components/context/SimulationContextProvider.jsx
@@ -210,8 +210,11 @@ function simulationReducer(prev, action) {
         },
       };
     }
-    case 'simulate_changes': {
-      return prev;
+    case 'set_simulation_results': {
+      return {
+        ...prev,
+        simulatedPredictions: action.data,
+      };
     }
     default: {
       throw Error('Unknown simulationReducer action: ' + action.type);
@@ -219,14 +222,9 @@ function simulationReducer(prev, action) {
   }
 }
 
-// TODO: set to default empty state
 // TODO: check for NPEs
 const DUMMY_SIM = {
-  selectedProject: {
-    // project_id: '49',
-    // project_name: 'Abdera',
-    // status: 'Graduated',
-  },
+  selectedProject: {},
   selectedProjectData: {
     id: null,
     details: {},
@@ -243,14 +241,7 @@ const DUMMY_SIM = {
     changes: new Map(),
     selectedPeriod: {},
   },
-  simulatedPredictions: [
-    { month: 10, p_grad: 0.1 },
-    { month: 13, p_grad: 0.5 },
-    { month: 14, p_grad: 0.3 },
-    { month: 15, p_grad: 0.1 },
-    { month: 16, p_grad: 0.7 },
-    { month: 17, p_grad: 0.7 },
-  ],
+  simulatedPredictions: [],
 };
 
 SimulationContextProvider.propTypes = {

--- a/frontend/src/components/context/SimulationContextProvider.jsx
+++ b/frontend/src/components/context/SimulationContextProvider.jsx
@@ -1,6 +1,5 @@
 import { pick } from 'lodash';
 import React, { useEffect, useReducer } from 'react';
-import { DUMMY_CHANGES, DUMMY_DATA } from '../UpdateFeatures/constants';
 import {
   getNewValueFromPChange,
   getPercentChange,
@@ -49,7 +48,7 @@ function simulationReducer(prev, action) {
       ]);
 
       return {
-        ...prev,
+        ...DUMMY_SIM,
         selectedProject: action.selectedValue,
         selectedProjectData: {
           id: action.id,
@@ -220,7 +219,8 @@ function simulationReducer(prev, action) {
   }
 }
 
-// TODO: set all data to null and check for NPEs
+// TODO: set to default empty state
+// TODO: check for NPEs
 const DUMMY_SIM = {
   selectedProject: {
     // project_id: '49',
@@ -228,32 +228,20 @@ const DUMMY_SIM = {
     // status: 'Graduated',
   },
   selectedProjectData: {
-    id: '112',
-    details: {
-      project_name: 'FtpServer',
-      start_date: '3/29/2003',
-      end_date: '12/18/2007',
-      status: 1,
-      pj_github_url: 'https://github.com/apache/FtpServer',
-      intro: 'A complete FTP Server based on Mina I/O system.',
-      sponsor: 'Incubator',
-    },
+    id: null,
+    details: {},
     predictions: [],
-    features: DUMMY_DATA,
+    features: [],
   },
   selectedFeature: {
     feature: 'num_commits',
     month: 1,
   },
   simulationData: {
-    changedPeriods: [
-      { key: '1_1', startMonth: 1, endMonth: 1 },
-      { key: '2_2', startMonth: 2, endMonth: 2 },
-      { key: '3_4', startMonth: 3, endMonth: 4 },
-    ],
-    changedMonths: new Set([1, 2, 3, 4]),
-    changes: new Map(DUMMY_CHANGES.map((c) => [c.id, c.change])),
-    selectedPeriod: { key: '1_1', startMonth: 1, endMonth: 1 },
+    changedPeriods: [],
+    changedMonths: new Set(),
+    changes: new Map(),
+    selectedPeriod: {},
   },
   simulatedPredictions: [
     { month: 10, p_grad: 0.1 },

--- a/frontend/src/components/endpoints.js
+++ b/frontend/src/components/endpoints.js
@@ -1,0 +1,4 @@
+export const API = 'http://127.0.0.1:8000';
+export const LIST_PROJECTS = `${API}/listprojects/`;
+export const GET_PROJECT_DETAILS = `${API}/getprojectdetails/`;
+export const GET_PROJECT_HISTORICAL_DATA = `${API}/getprojecthistoricaldata/`;

--- a/frontend/src/components/endpoints.js
+++ b/frontend/src/components/endpoints.js
@@ -2,3 +2,4 @@ export const API = 'http://127.0.0.1:8000';
 export const LIST_PROJECTS = `${API}/listprojects/`;
 export const GET_PROJECT_DETAILS = `${API}/getprojectdetails/`;
 export const GET_PROJECT_HISTORICAL_DATA = `${API}/getprojecthistoricaldata/`;
+export const SIMULATE_WITH_DELTAS = `${API}/simulate-with-deltas/`;


### PR DESCRIPTION
# Changes
- Restored `view.py` to latest version, for which changes were reverted by mistake from a bad merge commit.
- Pull project options from `${API}/listprojects/`.
- On project select, pull project details and prediction history from `${API}/getprojectdetails/`, and feature data history from `${API}/getprojecthistoricaldata/`. Display these in `ProjectDetails`/`ForecastGraph` and `FeatureGraph` respectively.
- Dynamically set month options for `DeltaSelector` based on the historical data available for the selected project.
- Implement `Simulate` button by calling `${API}/simulate-with-deltas/` on changes saved in `simContext.simulationData.changes`.
<img width="812" alt="image" src="https://github.com/user-attachments/assets/f72e4d1a-e50b-424a-83f2-683085ad8908" />
